### PR TITLE
Upgrade to node 14, bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:12-stretch-slim
+FROM node:14-bullseye-slim
 
-RUN runDeps="openssl ca-certificates git libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb patch" \
+RUN runDeps="openssl ca-certificates git libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb patch build-essential" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $runDeps \
  && apt-get clean \


### PR DESCRIPTION
We need node 14 to fix this error:

```
error jotai@1.3.4: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.22.1"

error Found incompatible module.
````
