### PR TITLE
Handle add-on resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- Handle add-on resolutions [`8`](https://github.com/plone/volto-addon-ci/pull/8)
 - increase default cypress start project timeout [`#5`](https://github.com/plone/volto-addon-ci/pull/5)
 - Improve cypress code coverage [`#4`](https://github.com/plone/volto-addon-ci/pull/4)
 - Upgrade to node 14, bullseye [`#6`](https://github.com/plone/volto-addon-ci/pull/6)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14-bullseye-slim
 
-RUN runDeps="openssl ca-certificates git libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb patch build-essential" \
+RUN runDeps="openssl ca-certificates git libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb patch build-essential jq" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $runDeps \
  && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ Docker Image optimized for running tests over Volto Add-ons
                  -e GIT_NAME=volto-slate \
              plone/volto-addon-ci
 
+## Resolutions
+
+Volto add-ons may depend on other JS libraries and/or other Volto add-ons. In order to
+enforce specific versions, you can use [selective dependency resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/) within your add-on.
+
+### Troubleshooting
+
+1. Make sure your Volto project `yarn.lock` is not polluted. You can always reset your Volto project `yarn.lock` with:
+
+        $ cd my-volto-project
+        $ rm yarn.lock
+        $ yo @plone/volto --skip-install
+        $ yarn
+
+2. Add-on resolutions don't work with `workspaces`, thus you'll need to define `resolutions` within Volto project.
+
+3. [See also](https://medium.com/swlh/welcome-to-dependency-hell-754a896f0440)
+
 ## Supported environment variables
 
 - `VOLTO` Volto version that the project will use. Default: Latest released version is used.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -69,6 +69,12 @@ if [ -f "/opt/frontend/my-volto-project/src/addons/$GIT_NAME/jest-addon.config.j
   cp /opt/frontend/my-volto-project/src/addons/$GIT_NAME/jest-addon.config.js /opt/frontend/my-volto-project/.
 fi
 
+resolutions=$(jq ".resolutions" /opt/frontend/my-volto-project/src/addons/$GIT_NAME/package.json)
+if [ "$resolutions" != "null" ]; then
+  jq ".resolutions = $resolutions" package.json > package.json.res
+  mv package.json.res package.json
+fi
+
 yarn
 
 if [[ "$1" == "test"* ]]; then


### PR DESCRIPTION
Sometimes add-ons requires specific dependencies resolutions, but add-on resolutions don't work if the add-on is in dev mode (workspaces) and therefore cypress tests are failing.

With this PR we try to overcome this issue and make cypress happy.