### PR TITLE
Force enableImmutableInstalls=false when running the yarn command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *~
+.*project
+.settings/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- Force enableImmutableInstalls=false when running the yarn command [#11](https://github.com/plone/volto-addon-ci/issues/11)
 - Copy <addon>/.project.eslintrc to <project>/.eslintrc.js [#9](https://github.com/plone/volto-addon-ci/pull/9)
 - Handle add-on resolutions [`8`](https://github.com/plone/volto-addon-ci/pull/8)
 - increase default cypress start project timeout [`#5`](https://github.com/plone/volto-addon-ci/pull/5)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -87,7 +87,8 @@ if [ "$resolutions" != "null" ]; then
   mv package.json.res package.json
 fi
 
-yarn
+# Allows the yarn.lock file to be changed.
+YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
 
 if [[ "$1" == "test"* ]]; then
   exec bash -c "set -o pipefail; RAZZLE_JEST_CONFIG=$RAZZLE_JEST_CONFIG CI=true yarn test src/addons/$GIT_NAME/src --watchAll=false --reporters=default --reporters=jest-junit --collectCoverage --coverageReporters lcov cobertura text 2>&1 | tee -a unit_tests_log.txt"


### PR DESCRIPTION
This allows the `yarn.lock` file to be changed, avoiding the error:

`YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.`

fixes #11 